### PR TITLE
Use additional constraints to reduce matches to a single VPC

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,6 @@
 data "aws_availability_zones" "available" {}
 
 data "aws_vpc" "default" {
-  default = true
+  id = "${var.vpc_id}"
+  default = "${var.default_vpc}"
 }


### PR DESCRIPTION
Hello there!

I hope PRs are welcomed :)

More constraints need to be used to reduce the VPC matches, because if you have more than one VPC, terraform will fail to apply the configuration with the following error:

```
module.eks.data.aws_vpc.default: data.aws_vpc.default: multiple VPCs matched; use additional constraints to reduce matches to a single VPC
```