### PR TITLE
Fix error applying plan when enable_kubectl is set to false

### DIFF
--- a/modules/cluster/kubectl.tf
+++ b/modules/cluster/kubectl.tf
@@ -32,7 +32,7 @@ resource "null_resource" "kubectl" {
 
 resource "null_resource" "aws_auth" {
   provisioner "local-exec" {
-    command = "kubectl apply --kubeconfig=./kubeconfig-${var.name}-cluster -f ./aws-auth.yaml"
+    command = "kubectl apply --kubeconfig=./kubeconfig-${var.name} -f ./aws-auth.yaml"
   }
 
   triggers {


### PR DESCRIPTION
If `enable_kubectl = false` terraform will fail with:

```
Error: Error applying plan:

1 error(s) occurred:

* module.eks.module.cluster.null_resource.kubectl: 1 error(s) occurred:

* Error running command '      KUBECONFIG=~/.kube/config:./kubeconfig-eks-test-cluster kubectl config view --flatten > ./kubeconfig_merged \
      && mv ./kubeconfig_merged ~/.kube/config \
      && kubectl config use-context eks-eks-test
    ': exit status 1. Output: mv: cannot move './kubeconfig_merged' to '/home/user/.kube/config': No such file or directory


Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```