### PR TITLE
Change to EKS Plaform version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Terraform version 0.10.3 or newer is required for this module to work.
 Kubernetes CLI 1.10 or newer with the Heptio Authenticator is required for the module to work.
 
 * [Kubernetes Client](https://kubernetes.io/docs/imported/release/notes/#client-binaries)
-* [Heptio Authenticator](https://github.com/heptio/authenticator)
+* [AWS IAM Authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator)
 
 ## Examples
 * [Basic](https://github.com/howdio/terraform-aws-eks/tree/master/examples/basic) - Basic Kubenetes cluster using the default VPC
@@ -40,11 +40,14 @@ Kubernetes CLI 1.10 or newer with the Heptio Authenticator is required for the m
 | enable_kubectl | When enabled, it will merge the cluster's configuration with the one located in ~/.kube/config. | string | `false` | no |
 | key_pair | Adds an EC2 Key Pair to the cluster nodes. | string | `` | no |
 | name | Name to be used on all the resources as identifier. | string | - | yes |
+| node_ami_id | AMI id for the node instances. | string | `` | no |
+| node_ami_lookup | AMI lookup name for the node instances. | string | `amazon-eks-node-*` | no |
 | node_instance_type | Instance type of the worker node. | string | `m5.large` | no |
 | node_max_size | Maximum size of the worker node AutoScaling Group. | string | `2` | no |
 | node_min_size | Minimum size of the worker node AutoScaling Group. | string | `1` | no |
 | node_subnet_ids | A list of VPC subnet IDs which the worker nodes are using. | string | `<list>` | no |
 | node_user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
+| node_bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
 | version | Kubernetes version to use for the cluster. | string | `1.10` | no |
 | vpc_id | ID of the VPC where to create the cluster resources. | string | `` | no |
 | workstation_cidr_blocks | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -34,15 +34,16 @@ module "eks" {
   enable_calico    = true
 }
 
-module "eks_nodes_burst" {
+module "eks_nodes_gpu" {
   source = "../../modules/nodes"
 
-  name                = "advanced-burst"
+  name                = "advanced-gpu"
   cluster_name        = "${module.eks.cluster_name}"
   cluster_endpoint    = "${module.eks.cluster_endpoint}"
   cluster_certificate = "${module.eks.cluster_certificate}"
   security_groups     = ["${module.eks.node_security_group}"]
   subnet_ids          = "${module.vpc.private_subnets}"
-  instance_type       = "t2.large"
+  ami_lookup          = "amazon-eks-gpu-node-*"
+  instance_type       = "p3.2xlarge"
   instance_profile    = "${module.eks.node_instance_profile}"
 }

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,11 @@ module "nodes" {
   security_groups     = ["${module.cluster.node_security_group}"]
   instance_profile    = "${module.cluster.node_instance_profile}"
   subnet_ids          = ["${local.node_subnet_ids}"]
+  ami_id              = "${var.node_ami_id}"
+  ami_lookup          = "${var.node_ami_lookup}"
   instance_type       = "${var.node_instance_type}"
   user_data           = "${var.node_user_data}"
+  bootstrap_arguments = "${var.node_bootstrap_arguments}"
   min_size            = "${var.node_min_size}"
   max_size            = "${var.node_max_size}"
   key_pair            = "${var.key_pair}"

--- a/modules/cluster/locals.tf
+++ b/modules/cluster/locals.tf
@@ -19,7 +19,7 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: heptio-authenticator-aws
+      command: aws-iam-authenticator
       args:
         - "token"
         - "-i"

--- a/modules/nodes/README.md
+++ b/modules/nodes/README.md
@@ -5,6 +5,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | ami_id | AMI id for the node instances. | string | `` | no |
+| ami_lookup | AMI lookup name for the node instances. | string | `amazon-eks-node-*` | no |
 | cluster_certificate | Certificate used to authenticate to the Kubernetes Controle Plane. | string | - | yes |
 | cluster_endpoint | Endpoint of the Kubernetes Controle Plane. | string | - | yes |
 | cluster_name | Cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster. | string | - | yes |
@@ -17,4 +18,5 @@
 | security_groups | The security groups assigned to the worker nodes. If it is incorrect, nodes will not be able to reach each other. | list | - | yes |
 | subnet_ids | Subnet IDs where worker nodes can be created. | list | - | yes |
 | user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
+| bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
 

--- a/modules/nodes/data.tf
+++ b/modules/nodes/data.tf
@@ -7,9 +7,9 @@ data "aws_subnet" "first" {
 data "aws_ami" "eks_node" {
   filter {
     name   = "name"
-    values = ["eks-worker-*"]
+    values = ["${var.ami_lookup}"]
   }
 
   most_recent = true
-  owners      = ["602401143452"] # Amazon Account ID
+  owners      = ["602401143452", "679593333241"] # Amazon Account ID
 }

--- a/modules/nodes/locals.tf
+++ b/modules/nodes/locals.tf
@@ -3,25 +3,9 @@ locals {
   ami_id = "${var.ami_id != "" ? var.ami_id : data.aws_ami.eks_node.id}"
 
   user_data = <<USERDATA
-#!/bin/bash -xe
-CA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki
-CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
-mkdir -p $CA_CERTIFICATE_DIRECTORY
-echo "${var.cluster_certificate}" | base64 -d > $CA_CERTIFICATE_FILE_PATH
-INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-sed -i s,MASTER_ENDPOINT,${var.cluster_endpoint},g /var/lib/kubelet/kubeconfig
-sed -i s,CLUSTER_NAME,${var.cluster_name},g /var/lib/kubelet/kubeconfig
-sed -i s,REGION,${data.aws_region.current.name},g /etc/systemd/system/kubelet.service
-sed -i s,MAX_PODS,${lookup(local.max_pods, var.instance_type, 8)},g /etc/systemd/system/kubelet.service
-sed -i s,MASTER_ENDPOINT,${var.cluster_endpoint},g /etc/systemd/system/kubelet.service
-sed -i s,INTERNAL_IP,$INTERNAL_IP,g /etc/systemd/system/kubelet.service
-DNS_CLUSTER_IP=10.100.0.10
-if [[ $INTERNAL_IP == 10.* ]] ; then DNS_CLUSTER_IP=172.20.0.10; fi
-sed -i s,DNS_CLUSTER_IP,$DNS_CLUSTER_IP,g /etc/systemd/system/kubelet.service
-sed -i s,CERTIFICATE_AUTHORITY_FILE,$CA_CERTIFICATE_FILE_PATH,g /var/lib/kubelet/kubeconfig
-sed -i s,CLIENT_CA_FILE,$CA_CERTIFICATE_FILE_PATH,g  /etc/systemd/system/kubelet.service
-systemctl daemon-reload
-systemctl restart kubelet kube-proxy
+#!/bin/bash
+set -o xtrace
+/etc/eks/bootstrap.sh ${var.cluster_name} ${var.bootstrap_arguments}
 ${var.user_data}
 USERDATA
 

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -1,11 +1,12 @@
 resource "aws_launch_configuration" "node" {
-  iam_instance_profile = "${var.instance_profile}"
-  image_id             = "${local.ami_id}"
-  instance_type        = "${var.instance_type}"
-  name_prefix          = "${var.name}"
-  key_name             = "${var.key_pair}"
-  security_groups      = ["${var.security_groups}"]
-  user_data_base64     = "${base64encode(local.user_data)}"
+  iam_instance_profile        = "${var.instance_profile}"
+  image_id                    = "${local.ami_id}"
+  instance_type               = "${var.instance_type}"
+  name_prefix                 = "${var.name}"
+  key_name                    = "${var.key_pair}"
+  associate_public_ip_address = false
+  security_groups             = ["${var.security_groups}"]
+  user_data_base64            = "${base64encode(local.user_data)}"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/nodes/variables.tf
+++ b/modules/nodes/variables.tf
@@ -33,6 +33,11 @@ variable "ami_id" {
   description = "AMI id for the node instances."
 }
 
+variable "ami_lookup" {
+  default     = "amazon-eks-node-*"
+  description = "AMI lookup name for the node instances."
+}
+
 variable "instance_type" {
   default     = "m5.large"
   description = "EC2 instance type for the node instances."
@@ -51,6 +56,11 @@ variable "min_size" {
 variable "max_size" {
   default     = 2
   description = "Maximum size of Node Group ASG."
+}
+
+variable "bootstrap_arguments" {
+  default     = ""
+  description = "Additional arguments when bootstrapping the EKS node."
 }
 
 variable "user_data" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,16 @@ variable "cluster_subnet_ids" {
   description = "A list of VPC subnet IDs which the cluster uses."
 }
 
+variable "node_ami_id" {
+  default     = ""
+  description = "AMI id for the node instances."
+}
+
+variable "node_ami_lookup" {
+  default     = "amazon-eks-node-*"
+  description = "AMI lookup name for the node instances."
+}
+
 variable "node_subnet_ids" {
   default     = []
   description = "A list of VPC subnet IDs which the worker nodes are using."
@@ -56,6 +66,11 @@ variable "node_max_size" {
 variable "node_user_data" {
   default     = ""
   description = "Additional user data used when bootstrapping the EC2 instance."
+}
+
+variable "node_bootstrap_arguments" {
+  default     = ""
+  description = "Additional arguments when bootstrapping the EKS node."
 }
 
 variable "workstation_cidr_blocks" {


### PR DESCRIPTION
Recent changes to AWS EKS makes it easier to provision clusters and nodes. In order to support this different AMI's should be used and the bootstrapper script needs to change.