### PR TITLE
Use the correct host-interface if the calico network policy engine is used

### DIFF
--- a/modules/cluster/locals.tf
+++ b/modules/cluster/locals.tf
@@ -119,7 +119,7 @@ spec:
             - "--auto-discover-default-role"
             - "--iptables=true"
             - "--host-ip=$(HOST_IP)"
-            - "--host-interface=eni+"
+            - "--host-interface=${var.enable_calico ? "cali+" : "eni+"}"
             - "--node=$(NODE_NAME)"
           env:
             - name: HOST_IP


### PR DESCRIPTION
When `enable_calico = true` kube2iam won't work because `host-interface = eni+` when it should be `host-interface = cali+`