### PR TITLE
Allow incoming https connections from the EKS masters security group

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -85,6 +85,16 @@ resource "aws_security_group_rule" "node_ingress_cluster" {
   type                     = "ingress"
 }
 
+resource "aws_security_group_rule" "node_ingress_cluster_https" {
+  description              = "Allow incoming https connections from the EKS masters security group"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.node.id}"
+  source_security_group_id = "${aws_security_group.cluster.id}"
+  type                     = "ingress"
+}
+
 resource "aws_security_group_rule" "cluster-ingress-node-https" {
   description              = "Allow pods to communicate with the cluster API Server"
   type                     = "ingress"


### PR DESCRIPTION
This fixes `metrics server` api not getting registered by allowing incoming https connections from the EKS masters security group.

More details https://github.com/kubernetes-incubator/metrics-server/issues/45