### PR TITLE
Rename the version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Kubernetes CLI 1.10 or newer with the AWS IAM Authenticator is required for the 
 | node_subnet_ids | A list of VPC subnet IDs which the worker nodes are using. | string | `<list>` | no |
 | node_user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
 | node_bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
-| version | Kubernetes version to use for the cluster. | string | `1.10` | no |
+| eks_version | Kubernetes version to use for the cluster. | string | `1.10` | no |
 | vpc_id | ID of the VPC where to create the cluster resources. | string | `` | no |
 | workstation_cidr | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |
 | aws_auth | Grant additional AWS users or roles the ability to interact with the EKS cluster. | string | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ module "cluster" {
   source = "./modules/cluster"
 
   name                    = "${var.name}"
-  version                 = "${var.version}"
+  eks_version             = "${var.eks_version}"
   vpc_id                  = "${local.vpc_id}"
   subnet_ids              = ["${local.cluster_subnet_ids}"]
   workstation_cidr        = ["${var.workstation_cidr}"]

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -10,7 +10,7 @@
 | enable_kubectl | When enabled, it will merge the cluster's configuration with the one located in ~/.kube/config. | string | `false` | no |
 | name | Name to be used on all the EKS Cluster resources as identifier. | string | - | yes |
 | subnet_ids | A list of VPC subnet IDs which the cluster uses. | string | `<list>` | no |
-| version | Kubernetes version to use for the cluster. | string | `1.10` | no |
+| eks_version | Kubernetes version to use for the cluster. | string | `1.10` | no |
 | vpc_id | ID of the VPC where to create the cluster resources. | string | - | yes |
 | workstation_cidr | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |
 | ssh_cidr | The CIDR blocks from which to allow incoming ssh connections to the EKS nodes. | string | `<list>` | no |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -107,7 +107,7 @@ resource "aws_security_group_rule" "cluster-ingress-node-https" {
 
 resource "aws_eks_cluster" "cluster" {
   name     = "${var.name}"
-  version  = "${var.version}"
+  version  = "${var.eks_version}"
   role_arn = "${aws_iam_role.cluster.arn}"
 
   vpc_config {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   description = "Name to be used on all the EKS Cluster resources as identifier."
 }
 
-variable "version" {
+variable "eks_version" {
   default     = "1.10"
   description = "Kubernetes version to use for the cluster."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   description = "Name to be used on all the resources as identifier."
 }
 
-variable "version" {
+variable "eks_version" {
   default     = "1.10"
   description = "Kubernetes version to use for the cluster."
 }


### PR DESCRIPTION
There is a corner case in which the variable to pass the EKS version can't be used:

```
module "eks" {
  source = "howdio/eks/aws//modules/cluster"

  version = "0.4.3"

  name = "basic"
  default_vpc = true

  enable_kubectl = true
  enable_dashboard = true
  enable_kube2iam = true
}
```

In the example above the `version` attribute from the module block is used to specify the module's version. `Version` constraints are supported only for modules installed from a module registry.

More details here: https://www.terraform.io/docs/modules/usage.html#module-versions