### PR TITLE
Enable spot instances usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Kubernetes CLI 1.10 or newer with the AWS IAM Authenticator is required for the 
 | vpc_id | ID of the VPC where to create the cluster resources. | string | `` | no |
 | workstation_cidr | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |
 | aws_auth | Grant additional AWS users or roles the ability to interact with the EKS cluster. | string | `<list>` | no |
+| spot_price | The maximum price to use for reserving spot instances. If set, the worker nodes will be spawned as spot instances instead of on demand. | string | `` | no |
 
 ## Outputs
 

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -1,7 +1,14 @@
 # Basic Kubernetes Cluster
 This example will create:
 * a new VPC
-* a new EKS cluster with GPU capable working nodes (using both private and public subnets).
+* a new EKS cluster, using both private and public subnets
+* two auto scaling groups to spawn GPU capable working nodes (on-demand and spot instances), using only private subnets
+
+To get the current market price for an instance (`p3.2xlarge`):
+
+```console
+$ aws ec2 describe-spot-price-history --start-time=$(date +%s) --product-descriptions="Linux/UNIX" --query 'SpotPriceHistory[*].{az:AvailabilityZone, price:SpotPrice}' --instance-types p3.2xlarge
+```
 
 ## Usage
 To run this example you need to execute:

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -50,7 +50,7 @@ AWSAUTH
 module "eks_nodes_gpu" {
   source = "../../modules/nodes"
 
-  name                = "eks-gpu-gpu"
+  name                = "eks_nodes_gpu"
   cluster_name        = "${module.eks.name}"
   cluster_endpoint    = "${module.eks.endpoint}"
   cluster_certificate = "${module.eks.certificate}"
@@ -58,5 +58,22 @@ module "eks_nodes_gpu" {
   subnet_ids          = "${module.vpc.private_subnets}"
   ami_lookup          = "amazon-eks-gpu-node-*"
   instance_type       = "p3.2xlarge"
+  bootstrap_arguments = "--kubelet-extra-args --node-labels=billing=on-demand"
   instance_profile    = "${module.eks.node_instance_profile}"
+}
+
+module "eks_nodes_gpu_spot" {
+  source = "../../modules/nodes"
+
+  name                = "eks_nodes_gpu_spot"
+  cluster_name        = "${module.eks.name}"
+  cluster_endpoint    = "${module.eks.endpoint}"
+  cluster_certificate = "${module.eks.certificate}"
+  security_groups     = ["${module.eks.node_security_group}"]
+  subnet_ids          = "${module.vpc.private_subnets}"
+  ami_lookup          = "amazon-eks-gpu-node-*"
+  instance_type       = "p3.2xlarge"
+  bootstrap_arguments = "--kubelet-extra-args --node-labels=billing=spot"
+  instance_profile    = "${module.eks.node_instance_profile}"
+  spot_price          = "1.10"
 }

--- a/modules/nodes/README.md
+++ b/modules/nodes/README.md
@@ -19,4 +19,5 @@
 | subnet_ids | Subnet IDs where worker nodes can be created. | list | - | yes |
 | user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
 | bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
+| spot_price | The maximum price to use for reserving spot instances. If set, the worker nodes will be spawned as spot instances instead of on demand. | string | `` | no |
 

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -7,6 +7,7 @@ resource "aws_launch_configuration" "node" {
   associate_public_ip_address = false
   security_groups             = ["${var.security_groups}"]
   user_data_base64            = "${base64encode(local.user_data)}"
+  spot_price                  = "${var.spot_price}"
 
   lifecycle {
     create_before_destroy = true

--- a/modules/nodes/variables.tf
+++ b/modules/nodes/variables.tf
@@ -72,3 +72,8 @@ variable "key_pair" {
   default     = ""
   description = "The EC2 Key Pair to allow SSH access to the instances."
 }
+
+variable "spot_price" {
+  default     = ""
+  description = "The maximum price to use for reserving spot instances. If set, the worker nodes will be spawned as spot instances instead of on demand."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,8 @@ variable "aws_auth" {
   default     = ""
   description = "Grant additional AWS users or roles the ability to interact with the EKS cluster."
 }
+
+variable "spot_price" {
+  default     = ""
+  description = "The maximum price to use for reserving spot instances. If set, the worker nodes will be spawned as spot instances instead of on demand."
+}


### PR DESCRIPTION
If `spot_price` is set, the auto scaling groups will request spot instances instead of on-demand nodes. The spot instances will be requested as long as the `spot_price` is bellow the market price.

This PR also updates the advanced example by:
* creating a new auto scaling group which will request spot instances
* creating a new auto scaling group which will request on-demand instances
* tagging the requested instances with `billing=spot` and `billing=on-demand` for better visibility and for a better `podAffinity`.

To get the market price for, let's say `p3.2xlarge`:
```console
$ aws ec2 describe-spot-price-history --start-time=$(date +%s) --product-descriptions="Linux/UNIX" --query 'SpotPriceHistory[*].{az:AvailabilityZone, price:SpotPrice}' --instance-types p3.2xlarge
```