### PR TITLE
Support disabling public access

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Kubernetes CLI 1.10 or newer with the AWS IAM Authenticator is required for the 
 |------|-------------|:----:|:-----:|:-----:|
 | availability_zone_count | Number of availability zones used in the region. | string | `2` | no |
 | availability_zones | List of availability zones in the region | string | `<list>` | no |
+| cluster_private_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `false` | no |
+| cluster_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `true` | no |
 | cluster_subnet_ids | A list of VPC subnet IDs which the cluster uses. | string | `<list>` | no |
 | default_vpc | Use the default VPC for creating your cluster resources. | string | `false` | no |
 | enable_calico | When enabled, it will install Calico for network policy support. | string | `false` | no |

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -15,6 +15,8 @@
 | workstation_cidr | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |
 | ssh_cidr | The CIDR blocks from which to allow incoming ssh connections to the EKS nodes. | string | `<list>` | no |
 | aws_auth | Grant additional AWS users or roles the ability to interact with the EKS cluster. | string | `<list>` | no |
+| cluster_private_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `false` | no |
+| cluster_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `true` | no |
 
 ## Outputs
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -111,8 +111,10 @@ resource "aws_eks_cluster" "cluster" {
   role_arn = "${aws_iam_role.cluster.arn}"
 
   vpc_config {
-    subnet_ids         = ["${var.subnet_ids}"]
-    security_group_ids = ["${aws_security_group.cluster.id}"]
+    subnet_ids               = ["${var.subnet_ids}"]
+    security_group_ids       = ["${aws_security_group.cluster.id}"]
+    endpoint_private_access  = "${var.cluster_private_access}"
+    endpoint_public_access   = "${var.cluster_public_access}"
   }
 
   depends_on = [

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -52,3 +52,13 @@ variable "aws_auth" {
   default     = ""
   description = "Grant additional AWS users or roles the ability to interact with the EKS cluster."
 }
+
+variable "cluster_private_access" {
+  default     = false
+  description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled."
+}
+
+variable "cluster_public_access" {
+  default     = true
+  description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,16 @@ variable "vpc_id" {
   description = "ID of the VPC where to create the cluster resources."
 }
 
+variable "cluster_private_access" {
+  default     = false
+  description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled."
+}
+
+variable "cluster_public_access" {
+  default     = true
+  description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled."
+}
+
 variable "cluster_subnet_ids" {
   default     = []
   description = "A list of VPC subnet IDs which the cluster uses."


### PR DESCRIPTION
[Amazon EKS Introduces Kubernetes API Server Endpoint Access Control](https://aws.amazon.com/about-aws/whats-new/2019/03/amazon-eks-introduces-kubernetes-api-server-endpoint-access-cont/). This PR enables the support for disabling public access to the EKS clusters.