### PR TITLE
Customize details about the `root_block_device`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Kubernetes CLI 1.10 or newer with the AWS IAM Authenticator is required for the 
 | node_subnet_ids | A list of VPC subnet IDs which the worker nodes are using. | string | `<list>` | no |
 | node_user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
 | node_bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
+| node_disk_size | The root device size for the worker nodes. | string | `` | yes |
 | eks_version | Kubernetes version to use for the cluster. | string | `1.10` | no |
 | vpc_id | ID of the VPC where to create the cluster resources. | string | `` | no |
 | workstation_cidr | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Kubernetes CLI 1.10 or newer with the AWS IAM Authenticator is required for the 
 | node_subnet_ids | A list of VPC subnet IDs which the worker nodes are using. | string | `<list>` | no |
 | node_user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
 | node_bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
-| node_disk_size | The root device size for the worker nodes. | string | `` | yes |
+| node_disk_size | The root device size for the worker nodes. | string | `20` | no |
 | eks_version | Kubernetes version to use for the cluster. | string | `1.10` | no |
 | vpc_id | ID of the VPC where to create the cluster resources. | string | `` | no |
 | workstation_cidr | CIDR blocks from which to allow inbound traffic to the Kubernetes control plane. | string | `<list>` | no |

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "1.66.0"
 
   name = "eks-gpu"
   cidr = "10.0.0.0/16"
@@ -60,6 +61,7 @@ module "eks_nodes_gpu" {
   instance_type       = "p3.2xlarge"
   bootstrap_arguments = "--kubelet-extra-args --node-labels=billing=on-demand"
   instance_profile    = "${module.eks.node_instance_profile}"
+  disk_size           = "50"
 }
 
 module "eks_nodes_gpu_spot" {
@@ -76,4 +78,5 @@ module "eks_nodes_gpu_spot" {
   bootstrap_arguments = "--kubelet-extra-args --node-labels=billing=spot"
   instance_profile    = "${module.eks.node_instance_profile}"
   spot_price          = "1.10"
+  disk_size           = "50"
 }

--- a/main.tf
+++ b/main.tf
@@ -52,4 +52,5 @@ module "nodes" {
   min_size            = "${var.node_min_size}"
   max_size            = "${var.node_max_size}"
   key_pair            = "${var.key_pair}"
+  disk_size           = "${var.node_disk_size}"
 }

--- a/modules/nodes/README.md
+++ b/modules/nodes/README.md
@@ -19,5 +19,6 @@
 | subnet_ids | Subnet IDs where worker nodes can be created. | list | - | yes |
 | user_data | Additional user data used when bootstrapping the EC2 instance. | string | `` | no |
 | bootstrap_arguments | Additional arguments when bootstrapping the EKS node. | string | `` | no |
+| disk_size | The root device size for the worker nodes. | string | `` | yes |
 | spot_price | The maximum price to use for reserving spot instances. If set, the worker nodes will be spawned as spot instances instead of on demand. | string | `` | no |
 

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -9,6 +9,10 @@ resource "aws_launch_configuration" "node" {
   user_data_base64            = "${base64encode(local.user_data)}"
   spot_price                  = "${var.spot_price}"
 
+  root_block_device {
+    volume_size = "${var.disk_size}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/nodes/variables.tf
+++ b/modules/nodes/variables.tf
@@ -63,6 +63,11 @@ variable "bootstrap_arguments" {
   description = "Additional arguments when bootstrapping the EKS node."
 }
 
+variable "disk_size" {
+  default     = ""
+  description = "The root device size for the worker nodes."
+}
+
 variable "user_data" {
   default     = ""
   description = "Additional user data used when bootstrapping the EC2 instance."

--- a/variables.tf
+++ b/variables.tf
@@ -84,7 +84,7 @@ variable "node_bootstrap_arguments" {
 }
 
 variable "node_disk_size" {
-  default     = ""
+  default     = "20"
   description = "The root device size for the worker nodes."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,11 @@ variable "node_bootstrap_arguments" {
   description = "Additional arguments when bootstrapping the EKS node."
 }
 
+variable "node_disk_size" {
+  default     = ""
+  description = "The root device size for the worker nodes."
+}
+
 variable "workstation_cidr" {
   default     = []
   description = "CIDR blocks from which to allow inbound traffic to the Kubernetes control plane."


### PR DESCRIPTION
This PR allows the user to customize details about the `root_block_device` of the worker nodes. For now only the `volume_size` can be customized, but in the future the user should be able to customize `volume_type`, `iops` and `delete_on_termination` as well.