### PR TITLE
Upgrade aws k8s cni plugin to 1.6.1

### DIFF
--- a/modules/cluster/addons.tf
+++ b/modules/cluster/addons.tf
@@ -57,7 +57,7 @@ resource "null_resource" "calico" {
   count = var.enable_calico ? 1 : 0
 
   provisioner "local-exec" {
-    command = "kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/aws-k8s-cni.yaml --kubeconfig ${path.root}/output/${var.name}/kubeconfig-${var.name}"
+    command = "kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6.1/config/v1.6/aws-k8s-cni.yaml --kubeconfig ${path.root}/output/${var.name}/kubeconfig-${var.name}"
   }
 
   triggers = {


### PR DESCRIPTION
This PR upgrades the AWS k8s cni plugin to the latest version. Without this change, when the EKS control plane is `1.16` the nodes will not enter in the `Ready` state:

```
  Ready            False   Thu, 14 May 2020 13:09:27 +0200   Thu, 14 May 2020 13:08:55 +0200   KubeletNotReady              runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized
```

A new version of the module should be released as soon as possible.